### PR TITLE
Practice count

### DIFF
--- a/templates/v2/analysis/event_counts.py
+++ b/templates/v2/analysis/event_counts.py
@@ -11,6 +11,10 @@ def round_to_nearest_100(x):
     return int(round(x, -2))
 
 
+def round_to_nearest_10(x):
+    return int(round(x, -1))
+
+
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--input_dir", type=str, required=True)
@@ -26,7 +30,7 @@ def get_number_of_events(df):
     return df.loc[:, "event_measure"].sum()
 
 
-def get_number_practices(df):
+def get_unique_practices(df):
     return df.loc[:, "practice"].unique()
 
 
@@ -46,12 +50,13 @@ def main():
             events[date] = num_events
             unique_patients = get_unique_patients(df)
             patients.extend(unique_patients)
-            unique_practices = get_number_practices(df)
+            unique_practices = get_unique_practices(df)
+
             practices.extend(unique_practices)
 
     total_events = round_to_nearest_100(sum(events.values()))
     total_patients = round_to_nearest_100(len(np.unique(patients)))
-    total_practices = round_to_nearest_100(len(np.unique(practices)))
+    total_practices = round_to_nearest_10(len(np.unique(practices)))
     events_in_latest_period = round_to_nearest_100(events[max(events.keys())])
 
     save_to_json(

--- a/templates/v2/analysis/render_report.py
+++ b/templates/v2/analysis/render_report.py
@@ -43,7 +43,6 @@ def get_data(
     time_event="",
     start_date="",
     end_date="",
-    num_practices=0,
     request_id="",
 ):
     """
@@ -61,7 +60,6 @@ def get_data(
         time_event (str): time event for the report
         start_date (str): start date for the report
         end_date (str): end date for the report
-        num_practices (int): number of practices in the report
         request_id (str): request id - this dictates the path to the data
     Returns:
         dict containing the data
@@ -151,7 +149,6 @@ def get_data(
         "time_value": time_value,
         "time_scale": time_scale,
         "time_event": time_event,
-        "num_practices": num_practices,
     }
     return report_data
 
@@ -194,7 +191,6 @@ def parse_args():
     parser.add_argument("--time-value", type=str, default="")
     parser.add_argument("--time-scale", type=str, default="")
     parser.add_argument("--time-event", type=str, default="")
-    parser.add_argument("--num-practices", type=int, default=0)
     parser.add_argument("--request-id", type=str, default="")
 
     return parser.parse_args()
@@ -218,7 +214,6 @@ if __name__ == "__main__":
         time_event=args.time_event,
         start_date=args.start_date,
         end_date=args.end_date,
-        num_practices=args.num_practices,
         request_id=args.request_id,
     )
 

--- a/templates/v2/analysis/report_template.html
+++ b/templates/v2/analysis/report_template.html
@@ -63,7 +63,7 @@
                 <p>Practice level variation in this measure is shown below as a decile chart. Each month, practices
                         are ranked by their rate of coding of <strong>{{ codelist_1_name }} AND {{ codelist_2_name }}</strong>,
                         from which deciles of activity are calculated.</p>
-                <p>The decile chart below is based on data from <strong>{{ num_practices }}</strong> practices.</p>
+                <p>The decile chart below is based on data from <strong>{{ summary_table_data.total_practices }}</strong> practices.</p>
                 <div>
                     <img src="{{ decile }}" alt="">
                 </div>

--- a/templates/v2/project.yaml.tmpl
+++ b/templates/v2/project.yaml.tmpl
@@ -121,7 +121,6 @@ actions:
       --time-event="{{ time_event }}"
       --start-date="{{ start_date }}"
       --end-date="{{ end_date }}"
-      --num-practices=1000
       --request-id="{{ id }}"
     needs: [event_counts_{{ id }}, deciles_chart_{{ id }}, top_5_table_{{ id }}, plot_measure_{{ id }}]
     outputs:


### PR DESCRIPTION
This addresses #35. This was simpler than expected because we were already producing the practice count, but it wasn't being used in the report.

The existing code is updated to round the practice count to the nearest 10, instead of nearest 100; we don't have to be as stringent for practice count as we are for patient population counts.