### PR TITLE
Further tweaks running the tests in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,6 @@ FROM ghcr.io/opensafely-core/python:latest AS python-dev
 
 COPY requirements.unit.txt /root/dev-dependencies.txt
 # fix pip-compile so it works by upgrading enough but not too much
-RUN pip install -U pip pip-tools 'click<8'
-RUN pip install -r /root/dev-dependencies.txt
+RUN --mount=type=cache,target=/root/.cache \
+    pip install -U pip pip-tools 'click<8' &&\
+    pip install -r /root/dev-dependencies.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,6 @@ lines_after_imports = 2
 skip_glob = [".direnv", "venv", ".venv", "rendered"]
 
 [tool.pytest.ini_options]
+filterwarnings = [
+    "ignore::DeprecationWarning"
+]

--- a/templates/v2/analysis/measures.py
+++ b/templates/v2/analysis/measures.py
@@ -2,7 +2,7 @@ import argparse
 from pathlib import Path
 
 import pandas as pd
-from report_utils import get_date_input_file, match_input_files
+from analysis.report_utils import get_date_input_file, match_input_files
 
 
 def round_column(df, col, decimals=-1):

--- a/templates/v2/project.yaml.tmpl
+++ b/templates/v2/project.yaml.tmpl
@@ -50,7 +50,7 @@ actions:
 
   generate_measures_{{ id }}:
     run: >
-      python:latest python analysis/measures.py
+      python:latest python -m analysis.measures
         --breakdowns="{{ demographics|join(',') }}"
         --input_dir="output/{{ id }}/joined"
         --measure="med_review"

--- a/templates/v2/tests/conftest.py
+++ b/templates/v2/tests/conftest.py
@@ -1,6 +1,0 @@
-import sys
-from pathlib import Path
-
-
-# handle the wonky path handling currently relied upon by analysis code
-sys.path.append(str(Path(__file__).parents[1] / "analysis"))

--- a/templates/v2/tests/test_measures.py
+++ b/templates/v2/tests/test_measures.py
@@ -1,8 +1,7 @@
+from analysis import measures
 from hypothesis import given
 from hypothesis.extra.pandas import column, data_frames, range_indexes
 from hypothesis.strategies import composite, integers, just, one_of
-
-from templates.v2.analysis import measures
 
 
 @composite


### PR DESCRIPTION
To fix the relative imports issue, we switch to running the script via
`python -m analysis.measures`. This allows us to use an absolute import
from within measures.py, which works both when run as an action, and
when importing for testing.

Also improved test-functional to work with running each templated
analysis in isolation. The previous sys.path munging had the potential
to break confusingly when we add a new templates analysis, so this is
much cleaner
