### PR TITLE
Fix age bands

### DIFF
--- a/interactive_templates/templates/v2/analysis/plot_measures.py
+++ b/interactive_templates/templates/v2/analysis/plot_measures.py
@@ -39,6 +39,7 @@ def main():
             parse_dates=["date"],
         )
         df = df.loc[df["value"] != "[Redacted]", :]
+        df["value"] = df["value"].astype(float)
         df = df.sort_values(by=["date"])
 
         plot_measures(

--- a/interactive_templates/templates/v2/analysis/plot_measures.py
+++ b/interactive_templates/templates/v2/analysis/plot_measures.py
@@ -29,7 +29,6 @@ def main():
         filename=f"{ args.output_dir }/plot_measures",
         column_to_plot="value",
         y_label="Rate per 1000",
-        as_bar=False,
         category=None,
     )
 
@@ -47,7 +46,6 @@ def main():
             filename=f"{ args.output_dir }/plot_measures_{breakdown}",
             column_to_plot="value",
             y_label="Rate per 1000",
-            as_bar=False,
             category=breakdown,
         )
 

--- a/interactive_templates/templates/v2/analysis/report_utils.py
+++ b/interactive_templates/templates/v2/analysis/report_utils.py
@@ -1,6 +1,7 @@
 import json
 import re
 
+import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 
 
@@ -28,54 +29,58 @@ def get_date_input_file(file: str) -> str:
 
 
 def plot_measures(
-    df,
-    filename: str,
-    column_to_plot: str,
-    y_label: str,
-    as_bar: bool = False,
-    category: str = None,
+    df, filename: str, column_to_plot: str, y_label: str, category: str = None
 ):
-    """Produce time series plot from measures table.  One line is plotted for each sub
-    category within the category column. Saves output in 'output' dir as jpeg file.
+    """Produce time series plot from measures table. If category is provided, one line is plotted for each sub
+    category within the category column. Saves output in 'output' dir as png file.
     Args:
         df: A measure table
         column_to_plot: Column name for y-axis values
         y_label: Label to use for y-axis
-        as_bar: Boolean indicating if bar chart should be plotted instead of line chart. Only valid if no categories.
-        category: Name of column indicating different categories
+        category: Name of column indicating different categories, optional
     """
-    plt.figure(figsize=(15, 8))
     if category:
         df[category] = df[category].fillna("Missing")
-        for unique_category in sorted(df[category].unique()):
-            # subset on category column and sort by date
-            df_subset = df[df[category] == unique_category].sort_values("date")
 
-            plt.plot(df_subset["date"], df_subset[column_to_plot])
-    else:
-        if as_bar:
-            df.plot.bar("date", column_to_plot, legend=False)
-        else:
-            plt.plot(df["date"], df[column_to_plot])
-
-    x_labels = sorted(df["date"].unique())
-    plt.ylabel(y_label)
-    plt.xlabel("Date")
-    plt.xticks(x_labels, rotation="vertical")
-    plt.ylim(
-        bottom=0,
-        top=1000
-        if df[column_to_plot].isnull().values.all()
-        else df[column_to_plot].max(),
-    )
+    _, ax = plt.subplots(figsize=(15, 8))
 
     if category:
-        plt.legend(
-            sorted(df[category].unique()), bbox_to_anchor=(1.04, 1), loc="upper left"
+        for unique_category in sorted(df[category].unique()):
+            df_subset = df[df[category] == unique_category].sort_values("date")
+            ax.plot(df_subset["date"], df_subset[column_to_plot])
+    else:
+        ax.plot(df["date"], df[column_to_plot])
+
+    ax.set(
+        ylabel=y_label,
+        xlabel="Date",
+        ylim=(
+            0,
+            1000
+            if df[column_to_plot].isnull().values.all()
+            else df[column_to_plot].max(),
+        ),
+    )
+
+    month_locator = mdates.MonthLocator()
+    ax.xaxis.set_major_locator(month_locator)
+    ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y-%m-%d"))
+    plt.xticks(rotation="vertical")
+
+    if category:
+        ax.legend(
+            sorted(df[category].unique()),
+            bbox_to_anchor=(1.04, 1),
+            loc="upper left",
+            fontsize=20,
         )
 
+    ax.margins(x=0)
+    ax.yaxis.label.set_size(25)
+    ax.xaxis.label.set_size(25)
+    ax.tick_params(axis="both", which="major", labelsize=20)
     plt.tight_layout()
-
+    plt.style.use("seaborn")
     plt.savefig(f"{filename}.png")
     plt.close()
 


### PR DESCRIPTION
When we generate the underlying data for the reports, we redact low counts, replacing them with `[REDACTED]`. When redaction occurs, this changes the dtype of the column to plot to an object instead of a float. This results in the figure not rendering properly (see [the age band figure in this report](https://jobs.opensafely.org/datalab/opensafely-internal/opensafely-internal-interactive/releases/01GW265C3SHG1G2XS6JE6VF7MR/output/01GVZM1JMFYG87V8YQVR7AW8NX/report.html))

This adds in a change to ensure the column to be plotted is a float, so the figure renders properly.

It also refactors the function used to plot the figures to make them more legible.