### PR TITLE
Events in latest week

### DIFF
--- a/interactive_templates/schema/v2.py
+++ b/interactive_templates/schema/v2.py
@@ -27,6 +27,7 @@ class Analysis:
     start_date: str = None
     end_date: str = None
     time_ever: bool = field(converter=bool, default=False)
+    week_of_latest_extract: str = None
 
 
 TEST_DEFAULTS = dict(
@@ -45,10 +46,10 @@ TEST_DEFAULTS = dict(
     filter_population="adults",
     repo="https://github.com/test/repo",
     time_scale="weeks",
-    time_event="before",
     time_value="4",
     time_ever=False,
     id="id",
     start_date="2019-01-01",
     end_date="2022-12-31",
+    week_of_latest_extract="2023-01-01",
 )

--- a/interactive_templates/schema/v2.py
+++ b/interactive_templates/schema/v2.py
@@ -27,7 +27,7 @@ class Analysis:
     start_date: str = None
     end_date: str = None
     time_ever: bool = field(converter=bool, default=False)
-    week_of_latest_extract: str = None
+    week_of_latest_extract: str = "2023-04-03"
 
 
 TEST_DEFAULTS = dict(
@@ -51,5 +51,4 @@ TEST_DEFAULTS = dict(
     id="id",
     start_date="2019-01-01",
     end_date="2022-12-31",
-    week_of_latest_extract="2023-01-01",
 )

--- a/interactive_templates/schema/v2.py
+++ b/interactive_templates/schema/v2.py
@@ -45,6 +45,7 @@ TEST_DEFAULTS = dict(
     filter_population="adults",
     repo="https://github.com/test/repo",
     time_scale="weeks",
+    time_event="before",
     time_value="4",
     time_ever=False,
     id="id",

--- a/interactive_templates/templates/v2/analysis/event_counts.py
+++ b/interactive_templates/templates/v2/analysis/event_counts.py
@@ -52,8 +52,9 @@ def main():
     practices = []
     practice_with_events = []
     events = {}
+    events_weekly = {}
 
-    for file in Path(args.input_dir).iterdir():
+    for file in Path(args.input_dir).rglob("*"):
         if match_input_files(file.name):
             date = get_date_input_file(file.name)
             df = pd.read_csv(file)
@@ -72,6 +73,16 @@ def main():
             practices.extend(unique_practices)
             practice_with_events.extend(unique_practices_with_events)
 
+        if match_input_files(file.name, weekly=True):
+            date = get_date_input_file(file.name, weekly=True)
+            df = pd.read_csv(file)
+            df["date"] = date
+            num_events = get_number_of_events(df)
+            events_weekly[date] = num_events
+
+    # there should only be one key in events_weekly, but we take the max anyway
+    latest_week = max(events_weekly.keys())
+    events_in_latest_week = round_to_nearest_100(events_weekly[latest_week])
     total_events = round_to_nearest_100(sum(events.values()))
     total_patients = round_to_nearest_100(len(np.unique(patients)))
     unique_patients_with_events = round_to_nearest_100(
@@ -91,6 +102,8 @@ def main():
             "events_in_latest_period": events_in_latest_period,
             "total_practices": total_practices,
             "total_practices_with_events": total_practices_with_events,
+            "events_in_latest_week": events_in_latest_week,
+            "latest_week": latest_week,
         },
         f"{args.output_dir}/event_counts.json",
     )

--- a/interactive_templates/templates/v2/analysis/event_counts.py
+++ b/interactive_templates/templates/v2/analysis/event_counts.py
@@ -44,6 +44,17 @@ def get_patients_with_events(df):
     return df_subset.loc[:, "patient_id"].unique()
 
 
+def generate_latest_week_range(latest_week_start):
+    latest_week_start = pd.to_datetime(latest_week_start)
+    latest_week_end = latest_week_start + pd.DateOffset(6)
+
+    latest_week_range = (
+        f"{latest_week_start:%Y-%m-%d} - {latest_week_end:%Y-%m-%d} inclusive"
+    )
+
+    return latest_week_range
+
+
 def main():
     args = parse_args()
 
@@ -82,6 +93,7 @@ def main():
 
     # there should only be one key in events_weekly, but we take the max anyway
     latest_week = max(events_weekly.keys())
+    latest_month = max(events.keys())
     events_in_latest_week = round_to_nearest_100(events_weekly[latest_week])
     total_events = round_to_nearest_100(sum(events.values()))
     total_patients = round_to_nearest_100(len(np.unique(patients)))
@@ -103,7 +115,8 @@ def main():
             "total_practices": total_practices,
             "total_practices_with_events": total_practices_with_events,
             "events_in_latest_week": events_in_latest_week,
-            "latest_week": latest_week,
+            "latest_week": generate_latest_week_range(latest_week),
+            "latest_month": pd.to_datetime(latest_month).strftime("%Y-%m"),
         },
         f"{args.output_dir}/event_counts.json",
     )

--- a/interactive_templates/templates/v2/analysis/report_template.html
+++ b/interactive_templates/templates/v2/analysis/report_template.html
@@ -141,6 +141,7 @@
                             <th>Total events</th>
                             <th>Total patients</th>
                             <th>Events in latest period</th>
+                            <th>Events in latest week ({{ summary_table_data.latest_week }})</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -148,6 +149,7 @@
                             <td>{{ summary_table_data.total_events }}</td>
                             <td>{{ summary_table_data.total_patients }}</td>
                             <td>{{ summary_table_data.events_in_latest_period }}</td>
+                            <td>{{ summary_table_data.events_in_latest_week }}</td>
                         </tr>
                     </tbody>
                 </table>

--- a/interactive_templates/templates/v2/analysis/report_template.html
+++ b/interactive_templates/templates/v2/analysis/report_template.html
@@ -140,7 +140,7 @@
                         <tr>
                             <th>Total events</th>
                             <th>Total patients</th>
-                            <th>Events in latest period</th>
+                            <th>Events in latest month ({{ summary_table_data.latest_month }})</th>
                             <th>Events in latest week ({{ summary_table_data.latest_week }})</th>
                         </tr>
                     </thead>

--- a/interactive_templates/templates/v2/analysis/report_utils.py
+++ b/interactive_templates/templates/v2/analysis/report_utils.py
@@ -61,20 +61,28 @@ def save_to_json(d, filename: str):
         json.dump(d, f)
 
 
-def match_input_files(file: str) -> bool:
+def match_input_files(file: str, weekly=False) -> bool:
     """Checks if file name has format outputted by cohort extractor"""
-    pattern = r"^input_20\d\d-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])\.csv.gz"
+    if weekly:
+        pattern = (
+            r"^input_weekly_20\d\d-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])\.csv.gz"
+        )
+    else:
+        pattern = r"^input_20\d\d-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])\.csv.gz"
     return True if re.match(pattern, file) else False
 
 
-def get_date_input_file(file: str) -> str:
+def get_date_input_file(file: str, weekly=False) -> str:
     """Gets the date in format YYYY-MM-DD from input file name string"""
     # check format
-    if not match_input_files(file):
+    if not match_input_files(file, weekly=weekly):
         raise Exception("Not valid input file format")
 
     else:
-        date = re.search(r"input_(.*).csv.gz", file)
+        if weekly:
+            date = re.search(r"input_weekly_(.*).csv.gz", file)
+        else:
+            date = re.search(r"input_(.*).csv.gz", file)
         return date.group(1)
 
 

--- a/interactive_templates/templates/v2/analysis/study_definition.py
+++ b/interactive_templates/templates/v2/analysis/study_definition.py
@@ -41,8 +41,8 @@ else:
     raise Exception("Unsupported time scale")
 
 if time_event == "before":
-    codelist_2_period_start = f"- {days} days"
-    codelist_2_period_end = ""
+    codelist_2_period_start = f"- {days}"
+    codelist_2_period_end = "+ 0"
 else:
     raise Exception("Unsupported time event")
 

--- a/interactive_templates/templates/v2/analysis/study_definition.py
+++ b/interactive_templates/templates/v2/analysis/study_definition.py
@@ -41,8 +41,8 @@ else:
     raise Exception("Unsupported time scale")
 
 if time_event == "before":
-    codelist_2_period_start = f"- {days}"
-    codelist_2_period_end = "+ 0"
+    codelist_2_period_start = f"- {days} days"
+    codelist_2_period_end = ""
 else:
     raise Exception("Unsupported time event")
 

--- a/interactive_templates/templates/v2/project.yaml.tmpl
+++ b/interactive_templates/templates/v2/project.yaml.tmpl
@@ -14,6 +14,29 @@ actions:
       highly_sensitive:
         cohort: output/{{ id }}/input_ethnicity.csv.gz
 
+  generate_study_population_weekly_{{ id }}:
+    run: cohortextractor:latest generate_cohort
+      --study-definition study_definition
+      --param codelist_1_path="{{ codelist_1.path }}"
+      --param codelist_1_type="{{ codelist_1.type }}"
+      --param codelist_2_path="{{ codelist_2.path }}"
+      --param codelist_2_type="{{ codelist_2.type }}"
+      --param codelist_1_frequency="weekly"
+      --param time_value="{{ time_value }}"
+      --param time_ever="{{ time_ever }}"
+      --param time_scale="{{ time_scale }}"
+      --param time_event="{{ time_event }}"
+      --param codelist_2_comparison_date="end_date"
+      --param operator="AND"
+      --param population="{{ filter_population }}"
+      --param breakdowns=""
+      --index-date_range="{{ week_of_latest_extract }} to {{ week_of_latest_extract }} by week"
+      --output-dir=output/{{ id }}
+      --output-format=csv.gz
+      --output-file=output/{{ id }}/input_weekly_{{week_of_latest_extract}}.csv.gz
+    outputs:
+      highly_sensitive:
+        cohort: output/{{ id }}/input_weekly_{{ week_of_latest_extract }}.csv.gz
 
   generate_study_population_{{ id }}:
     run: cohortextractor:latest generate_cohort
@@ -89,8 +112,8 @@ actions:
 
   event_counts_{{ id }}:
     run: >
-      python:latest python analysis/event_counts.py --input-dir="output/{{ id }}/joined" --output-dir="output/{{ id }}"
-    needs: [join_cohorts_{{ id }}]
+      python:latest python analysis/event_counts.py --input-dir="output/{{ id }}" --output-dir="output/{{ id }}"
+    needs: [join_cohorts_{{ id }}, generate_study_population_weekly_{{ id }}]
     outputs:
       moderately_sensitive:
         measure: output/{{ id }}/event_counts.json

--- a/tests/test_v2.py
+++ b/tests/test_v2.py
@@ -7,6 +7,8 @@ from interactive_templates.schema import v2
 
 def test_v2_functional(tmp_path):
     analysis = v2.Analysis(**v2.TEST_DEFAULTS)
+
     render_analysis(analysis, tmp_path)
+
     assert local_run.main(tmp_path, ["run_all"])
     assert (tmp_path / "output/id/report.html").exists()


### PR DESCRIPTION
This adds a count of the number of events in the latest week to the report. This requires an additional action the pipeline to extract a single weekly cohort, which uses the same study definition as the monthly extracts but with different paramaterisation. It also required some changes to the date handling within the study definition - this isn't very nice because we're having to dynamically create string representation of dates that can be handled by cohort extractor. I'm not sure if there's a better way - this will only get more messy as we add support for forward lookup or want to update the comparison date for codelist 2 (to something other than the end date of the week/month).


Note: this requires one more value to be passed to the analysis code.  I've called it `weekly_start_date`, which will be the start of the latest week we have data for. `end_date` will then be the start of the latest full month we have data for. I'll leave this as draft until we have support for that.