### PR TITLE
fix: enforce typing in schema

### DIFF
--- a/interactive_templates/render.py
+++ b/interactive_templates/render.py
@@ -165,7 +165,10 @@ def main():
     def set_value(d, name, value):
         """Set dotted values in a nested dictlike object."""
         if "." not in name:
-            d[name] = value
+            if "," in value:
+                d[name] = value.split(",")
+            else:
+                d[name] = value
         else:
             key, rest = name.split(".", 2)
             set_value(d[key], rest, value)

--- a/interactive_templates/schema/v2.py
+++ b/interactive_templates/schema/v2.py
@@ -1,3 +1,5 @@
+from attrs import field, validators
+
 from interactive_templates.schema import Codelist, interactive_schema
 
 
@@ -14,11 +16,11 @@ class Analysis:
     codelist_1: Codelist
     codelist_2: Codelist | None
     created_by: str
-    demographics: list
+    demographics: list = field(validator=validators.instance_of(list))
     filter_population: str
     repo: str
     time_scale: str
-    time_value: int
+    time_value: int = field(converter=int)
     title: str
     purpose: str
     id: str | None = None  # noqa: A003


### PR DESCRIPTION
attrs doesn't validate inputs by default, so we add some validation of
the non-string types.

Also support csv lists for render cli args, so we can do `just render
demographics=age,sex`
