### PR TITLE
Add workflow to create job-server PR on push to main

### DIFF
--- a/.github/workflows/create-job-server-pr.yml
+++ b/.github/workflows/create-job-server-pr.yml
@@ -1,0 +1,47 @@
+---
+name: "Create PR to update job-server"
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - CI
+    branches:
+      - main
+    types:
+      - completed
+
+jobs:
+  create_job_server_pr:
+    if: ${{ (github.event.workflow_run.conclusion == 'success') || (github.event_name == 'workflow_dispatch') }}
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: opensafely-core/job-server
+
+      - uses: opensafely-core/setup-action@v1
+        with:
+          install-just: true
+          python-version: "3.11"
+
+      - name: Update requirement to latest
+        run: just update-interactive-templates "$GITHUB_REF"
+
+      - name: Create a Pull Request if there are any changes
+        id: create_pr
+        uses: peter-evans/create-pull-request@5b4a9f6a9e2af26e5f02351490b90d01eb8ec1e5 # v5.0.0
+        with:
+          token: "${{ secrets.JOB_SERVER_PR_TOKEN }}"
+          branch: bot/update-interactive-templates
+          commit-message: "feat: Update interactive templates to latest version"
+          title: "Update interactive templates to latest version"
+          body: "Update interative-templates to ${{ github.sha }}"
+
+      # untested
+      #- name: Enable automerge
+      #  if: steps.create_pr.outputs.pull-request-operation == 'created'
+      #  env:
+      #    GH_TOKEN: "${{ secrets.JOB_SERVER_PR_TOKEN }} "
+      #  run: gh pr merge --merge --auto --squash ${{ steps.create_pr.outputs.pull-request-number }}

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -87,3 +87,24 @@ To run these tests:
 ```
 just test-functional
 ```
+
+
+### Github auto PR Token
+
+The workflow in `.github/workflows/create-job-server-pr.yml` needs a fine
+grained PAT as a repository secret in order to work.
+
+Any tech team member can generate a PAT using their account, as the
+fine-grained nature means we can restrict it appropriately.
+
+1. Go to https://github.com/settings/tokens?type=beta
+1. Generate New Token:
+    1. Name: `JOB_SERVER_PR_TOKEN`
+    1. Expiry: 90 days
+    1. Description: "Token to allow interactive-templates to create job-server PRs"
+    1. Resource Owner: opensafely-core
+    1. Repository Access: Only Select Respositories, select `job-server`.
+    1. Account Permissions:
+        1. Contents - Read and Write
+        1. Pull Requests - Read and Write
+1. Add token value as repository secret `JOB_SERVER_PR_TOKEN`


### PR DESCRIPTION
I temporarily enabled this to trigger on `pull_request` in order to test it. 

It successfully created a job-server PR that DTRT and passed tests: https://github.com/opensafely-core/job-server/pull/3024

I have not enabled automerge for now, so we can suck it an see for a bit.
