### PR TITLE
Handle "0 weeks before" correctly.

### DIFF
--- a/interactive_templates/templates/v2/analysis/report_template.html
+++ b/interactive_templates/templates/v2/analysis/report_template.html
@@ -44,10 +44,10 @@
                 <p>
                     The measure shows the number of people each month who had both a code from
                     codelist 1 added to their health record and a code from codelist 2 added to
-                    their health record in the same month or up to <strong>{{ time_value }}
-                    {{ time_scale }} {{ time_event }}</strong> the start of that month. This monthly
-                    measure is calculated for the period between <strong>{{ start_date }}</strong>
-                    and <strong>{{ end_date }}</strong>.
+                    their health record in the same month{% if time_value == "0" %}.{% else %} or up to
+                    <strong>{{ time_value }} {{ time_scale }} {{ time_event }}</strong> the start of
+                    that month.{% endif %} This monthly measure is calculated for the period between
+                    <strong>{{ start_date }}</strong> and <strong>{{ end_date }}</strong>.
                 </p>
 
                 <p>

--- a/interactive_templates/templates/v2/tests/test_report_utils.py
+++ b/interactive_templates/templates/v2/tests/test_report_utils.py
@@ -1,0 +1,32 @@
+import pytest
+from analysis.report_utils import calculate_variable_windows_codelist_2
+
+
+@pytest.mark.parametrize(
+    "codelist_1_date_range, codelist_2_comparison_date, codelist_2_period_start, codelist_2_period_end, expected_date_range",
+    [
+        (
+            ["index_date", "last_day_of_month(index_date"],
+            "end_date",
+            "- 0 days",
+            "",
+            ["index_date - 0 days", "last_day_of_month(index_date"],
+        ),
+    ],
+)
+def test_calculate_variable_windows_codelist_2(
+    codelist_1_date_range,
+    codelist_2_comparison_date,
+    codelist_2_period_start,
+    codelist_2_period_end,
+    expected_date_range,
+):
+    assert (
+        calculate_variable_windows_codelist_2(
+            codelist_1_date_range,
+            codelist_2_comparison_date,
+            codelist_2_period_start,
+            codelist_2_period_end,
+        )
+        == expected_date_range
+    )

--- a/tests/test_v2.py
+++ b/tests/test_v2.py
@@ -12,3 +12,13 @@ def test_v2_functional(tmp_path):
 
     assert local_run.main(tmp_path, ["run_all"])
     assert (tmp_path / "output/id/report.html").exists()
+
+
+def test_v2_functional_time_value_zero(tmp_path):
+    analysis = v2.Analysis(**v2.TEST_DEFAULTS)
+    analysis.time_value = 0
+
+    render_analysis(analysis, tmp_path)
+
+    assert local_run.main(tmp_path, ["run_all"])
+    assert (tmp_path / "output/id/report.html").exists()


### PR DESCRIPTION
https://github.com/opensafely-core/job-server/pull/3038 adds the option to specify 0 for `time_value`. We want to make sure this is handled correctly by the analysis code. This adds a test for `calculate_variable_windows_codelist_2` to check the study def specification is as we expect and then updates the functional tests to include a parameter set with `time_value=0` to check cohortextractor handles what we're passing it.