### PR TITLE
Formatting fixes for the report template

### DIFF
--- a/interactive_templates/templates/v2/analysis/report_template.html
+++ b/interactive_templates/templates/v2/analysis/report_template.html
@@ -32,14 +32,10 @@
 
             <section id="intro">
                 <h2>Measure description</h2>
-                <p>This report shows the monthly recording patterns for a measure
-                    of primary care activity produced using OpenSAFELY Interactive.
-                    This measure is made up of two clinical activities, defined by
-                    the codelists below:
-                </p>
+                <p>This report shows the monthly recording patterns for a measure of primary care activity produced using OpenSAFELY Interactive. This measure is made up of two clinical activities, defined by the codelists below:</p>
                 <ul>
-                    <li>Codelist 1 - <strong>{{ codelist_1_name }}</strong> (<a href="{{ codelist_1_link }}">View on OpenCodelists</a>)</li>
-                    <li>Codelist 2 - <strong>{{ codelist_2_name }}</strong> (<a href="{{ codelist_2_link }}">View on OpenCodelists</a>)</li>
+                    <li>Codelist 1 - <strong>{{ codelist_1_name }}</strong> <span>(<a href="{{ codelist_1_link }}" target="_blank" rel="noopener noreferrer">View on OpenCodelists</a>)</span></li>
+                    <li>Codelist 2 - <strong>{{ codelist_2_name }}</strong> <span>(<a href="{{ codelist_2_link }}" target="_blank" rel="noopener noreferrer">View on OpenCodelists</a>)</span></li>
                 </ul>
                 <p>
                     The measure shows the number of people each month who had both a code from
@@ -56,10 +52,7 @@
                     {% if breakdowns|length >0 %}
                     A breakdown of this measure by
                     {% for b in breakdowns %}
-                    <span>
-                        <strong>{{ b.title|lower }}</strong>
-                        {% if not loop.last %},{% endif %}
-                    </span>
+                    <span><strong>{{ b.title|lower }}</strong>{% if not loop.last %}, {% endif %}</span>
                     {% endfor %} is also provided.
                     {% endif %}
                 </p>
@@ -87,7 +80,7 @@
                         may wish to discuss the results of this analysis with an experienced electronic health
                         records researcher or analyst who understands how clinical activity is coded in general
                         practice. Alternatively, you may wish to perform your own analysis by writing and deploying
-                        code via <a href="https://www.opensafely.org/">OpenSAFELY</a>, which will allow you to explore the data in more detail.
+                        code via <a href="https://www.opensafely.org/" target="_blank" rel="noopener noreferrer">OpenSAFELY</a>, which will allow you to explore the data in more detail.
                     </li>
                     <li>
                         The results displayed in OpenSAFELY Interactive reports are automatically generated based
@@ -146,10 +139,10 @@
                     </thead>
                     <tbody>
                         <tr>
-                            <td>{{ summary_table_data.total_events }}</td>
-                            <td>{{ summary_table_data.total_patients }}</td>
-                            <td>{{ summary_table_data.events_in_latest_period }}</td>
-                            <td>{{ summary_table_data.events_in_latest_week }}</td>
+                            <td data-format-number="true">{{ summary_table_data.total_events }}</td>
+                            <td data-format-number="true">{{ summary_table_data.total_patients }}</td>
+                            <td data-format-number="true">{{ summary_table_data.events_in_latest_period }}</td>
+                            <td data-format-number="true">{{ summary_table_data.events_in_latest_week }}</td>
                         </tr>
                     </tbody>
                 </table>
@@ -270,12 +263,8 @@
                     The figures below show the monthly rate per 1000
                     patients for the measure described above, broken down by
                     {% for b in breakdowns %}
-                    <span>
-                        {{ b.title|lower }}
-                        {% if not loop.last %},
-                        {% endif %}
-                    </span>
-                    {% endfor %}.
+                    <span><strong>{{ b.title|lower }}</strong>{% if not loop.last %}, {% else %}.{% endif %}</span>
+                    {% endfor %}
                 </p>
 
                 {% set i=namespace(value=3) %}
@@ -287,7 +276,7 @@
                     {% if b.link %}
                     <p>
                         <strong>Codelist link: </strong>
-                        <a href="{{ b.link }}">{{ b.link_description }}</a>
+                        <a href="{{ b.link }}" target="_blank" rel="noopener noreferrer">{{ b.link_description }}</a>
                     </p>
                     {% endif %}
 


### PR DESCRIPTION
- Make all links open in new tabs
- Improve formatting of lists turned in to comma separated text
- Add option for `data-format-number="true"` to allow JS styling of numbers