### PR TITLE
Figure fixes

### DIFF
--- a/interactive_templates/templates/v2/analysis/event_counts.py
+++ b/interactive_templates/templates/v2/analysis/event_counts.py
@@ -20,6 +20,10 @@ round_to_nearest_100 = functools.partial(round_to_nearest, base=100)
 round_to_nearest_10 = functools.partial(round_to_nearest, base=10)
 
 
+def replace_zero_with_redacted(x):
+    return x if x > 0 else "[REDACTED]"
+
+
 def get_summary_stats(df):
     required_columns = {"patient_id", "event_measure", "practice"}
     assert required_columns.issubset(set(df.columns))
@@ -89,17 +93,27 @@ def main():
     # there should only be one key in events_weekly, but we take the max anyway
     latest_week = max(events_weekly.keys())
     latest_month = max(events.keys())
-    events_in_latest_week = round_to_nearest_100(events_weekly[latest_week])
-    total_events = round_to_nearest_100(sum(events.values()))
-    total_patients = round_to_nearest_100(len(np.unique(patients)))
-    unique_patients_with_events = round_to_nearest_100(
-        len(np.unique(patients_with_events))
+    events_in_latest_week = replace_zero_with_redacted(
+        round_to_nearest_100(events_weekly[latest_week])
     )
+
+    total_events = replace_zero_with_redacted(
+        round_to_nearest_100(sum(events.values()))
+    )
+    total_patients = replace_zero_with_redacted(
+        round_to_nearest_100(len(np.unique(patients)))
+    )
+    unique_patients_with_events = replace_zero_with_redacted(
+        round_to_nearest_100(len(np.unique(patients_with_events)))
+    )
+
     total_practices = round_to_nearest_10(len(np.unique(practices)))
     total_practices_with_events = round_to_nearest_10(
         len(np.unique(practice_with_events))
     )
-    events_in_latest_period = round_to_nearest_100(events[max(events.keys())])
+    events_in_latest_period = replace_zero_with_redacted(
+        round_to_nearest_100(events[max(events.keys())])
+    )
 
     save_to_json(
         {

--- a/interactive_templates/templates/v2/analysis/plot_measures.py
+++ b/interactive_templates/templates/v2/analysis/plot_measures.py
@@ -54,6 +54,29 @@ def main():
                     "Least deprived",
                 ],
             )
+
+        elif breakdown == "age":
+            plot_measures(
+                df_subset,
+                filename=f"{ args.output_dir }/plot_measures_{breakdown}",
+                column_to_plot="value",
+                y_label="Rate per 1000",
+                category="group_value",
+                category_order=[
+                    "0-5",
+                    "6-10",
+                    "11-17",
+                    "0-17",
+                    "18-29",
+                    "30-39",
+                    "40-49",
+                    "50-59",
+                    "60-69",
+                    "70-79",
+                    "80+",
+                ],
+            )
+
         else:
             plot_measures(
                 df_subset,

--- a/interactive_templates/templates/v2/analysis/plot_measures.py
+++ b/interactive_templates/templates/v2/analysis/plot_measures.py
@@ -1,6 +1,7 @@
 import argparse
 
 import pandas as pd
+import seaborn as sns
 from report_utils import deciles_chart, plot_measures
 
 
@@ -17,6 +18,8 @@ def parse_args():
 def main():
     args = parse_args()
     breakdowns = args.breakdowns
+
+    sns.set_style("darkgrid")
 
     df = pd.read_csv(
         f"{ args.output_dir }/joined/measure_all.csv", parse_dates=["date"]

--- a/interactive_templates/templates/v2/analysis/report_template.html
+++ b/interactive_templates/templates/v2/analysis/report_template.html
@@ -155,13 +155,13 @@
             <section id="population-level">
                 <h2>Population level rate</h2>
                 <p>
-                    The figure below shows the monthly rate per 1000
+                    The figure below shows the monthly rate per 1000 registered
                     patients for the measure described above.
                 </p>
                 <figure>
                     {{ display_image(population_plot.path, population_plot.data) }}
                     <figcaption>
-                        <strong>Figure 1</strong>. The monthly rate per 1000 patients
+                        <strong>Figure 1</strong>. The monthly rate per 1000 registered patients
                         in the selected population for the specified measure between
                         {{ start_date }} and {{ end_date }}.
                     </figcaption>
@@ -194,7 +194,7 @@
                     {{ display_image(decile.path, decile.data) }}
                     <figcaption>
                         <strong>Figure 2</strong>. Practice level decile chart showing
-                        practice level variation in the rate per 1000 patients who satisfy the
+                        practice level variation in the rate per 1000 registered patients who satisfy the
                         specified measure between {{ start_date }} and {{ end_date }}.
                     </figcaption>
                 </figure>
@@ -264,7 +264,7 @@
             <section id="breakdowns">
                 <h2>Demographic breakdowns</h2>
                 <p>
-                    The figures below show the monthly rate per 1000
+                    The figures below show the monthly rate per 1000 registered
                     patients for the measure described above, broken down by
                     {% for b in breakdowns %}
                     <span><strong>{{ b.title|lower }}</strong>{% if not loop.last %}, {% else %}.{% endif %}</span>

--- a/interactive_templates/templates/v2/analysis/report_utils.py
+++ b/interactive_templates/templates/v2/analysis/report_utils.py
@@ -6,6 +6,7 @@ import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+import seaborn as sns
 
 
 BASE_DIR = Path(__file__).parents[1]
@@ -106,16 +107,35 @@ def plot_measures(
         df[category] = df[category].fillna("Missing")
 
     _, ax = plt.subplots(figsize=(15, 8))
+    palette = sns.color_palette("tab10")
 
     if category:
         if category_order:
             for unique_category in category_order:
                 df_subset = df[df[category] == unique_category].sort_values("date")
-                ax.plot(df_subset["date"], df_subset[column_to_plot])
+
+                sns.lineplot(
+                    x="date",
+                    y=column_to_plot,
+                    data=df_subset,
+                    palette=palette,
+                    ax=ax,
+                    label=unique_category,
+                )
+
         else:
             for unique_category in df[category].unique():
                 df_subset = df[df[category] == unique_category].sort_values("date")
-                ax.plot(df_subset["date"], df_subset[column_to_plot])
+
+                sns.lineplot(
+                    x="date",
+                    y=column_to_plot,
+                    data=df_subset,
+                    palette=palette,
+                    ax=ax,
+                    label=unique_category,
+                )
+
     else:
         ax.plot(df["date"], df[column_to_plot])
 

--- a/interactive_templates/templates/v2/analysis/report_utils.py
+++ b/interactive_templates/templates/v2/analysis/report_utils.py
@@ -157,20 +157,11 @@ def plot_measures(
     plt.xticks(rotation="vertical")
 
     if category:
-        if category_order:
-            ax.legend(
-                category_order,
-                bbox_to_anchor=(1.04, 1),
-                loc="upper left",
-                fontsize=20,
-            )
-        else:
-            ax.legend(
-                sorted(df[category].unique()),
-                bbox_to_anchor=(1.04, 1),
-                loc="upper left",
-                fontsize=20,
-            )
+        ax.legend(
+            bbox_to_anchor=(1.04, 1),
+            loc="upper left",
+            fontsize=20,
+        )
 
     ax.margins(x=0)
     ax.yaxis.label.set_size(25)

--- a/interactive_templates/templates/v2/analysis/report_utils.py
+++ b/interactive_templates/templates/v2/analysis/report_utils.py
@@ -294,17 +294,25 @@ def deciles_chart(df, filename, period_column=None, column=None, title="", ylabe
     label_seen = []
     for percentile in range(1, 100):
         data = df[df["percentile"] == percentile]
+        add_label = False
 
         if percentile == 50:
             style = linestyles["median"]
-            label = style["label"]
+            add_label = True
+        elif percentile < 10 or percentile > 90:
+            style = linestyles["percentile"]
+            if "percentile" not in label_seen:
+                label_seen.append("percentile")
+                add_label = True
         else:
             style = linestyles["decile"]
             if "decile" not in label_seen:
                 label_seen.append("decile")
-                label = style["label"]
-            else:
-                label = "_nolegend_"
+                add_label = True
+        if add_label:
+            label = style["label"]
+        else:
+            label = "_nolegend_"
 
         ax.plot(
             data[period_column],

--- a/interactive_templates/templates/v2/analysis/report_utils.py
+++ b/interactive_templates/templates/v2/analysis/report_utils.py
@@ -6,7 +6,6 @@ import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import seaborn as sns
 
 
 BASE_DIR = Path(__file__).parents[1]
@@ -157,7 +156,6 @@ def plot_measures(
     ax.xaxis.label.set_size(25)
     ax.tick_params(axis="both", which="major", labelsize=20)
     plt.tight_layout()
-    plt.style.use("seaborn")
     plt.savefig(f"{filename}.png")
     plt.close()
 
@@ -252,8 +250,6 @@ def deciles_chart(df, filename, period_column=None, column=None, title="", ylabe
         title: the title of the chart
         ylabel: the label of the y-axis of the chart
     """
-
-    sns.set_style("darkgrid")
 
     fig, ax = plt.subplots(figsize=(15, 8))
 

--- a/interactive_templates/templates/v2/analysis/report_utils.py
+++ b/interactive_templates/templates/v2/analysis/report_utils.py
@@ -132,7 +132,8 @@ def plot_measures(
 
     month_locator = mdates.MonthLocator()
     ax.xaxis.set_major_locator(month_locator)
-    ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y-%m-%d"))
+    ax.xaxis.set_major_formatter(mdates.DateFormatter("%B %Y"))
+    ax.xaxis.set_major_locator(mdates.MonthLocator(interval=2))
     plt.xticks(rotation="vertical")
 
     if category:


### PR DESCRIPTION
- Makes redacted event counts show as `[REDACTED]` instead of 0.
- Orders legend for the age plot, and shows the outer deciles in the deciles chart legend.
- Makes the rate denominator clear.
- Fixes figure styling
  - Updates colour palette so lines are more distinguishable
  - Makes x ticks less frequent
  - Applies styling consistently to all charts.
 
In passing,  addresses #147. In seaborn, missing data is not extrapolated over when plotting a line chart.