### PR TITLE
Render json config and use it instead of passing cli args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ interactive_templates/templates/*/interactive_codelists/
 interactive_templates/templates/*/metadata/
 interactive_templates/templates/*/output/
 interactive_templates/templates/*/project.yaml
+interactive_templates/templates/*/config.json

--- a/interactive_templates/render.py
+++ b/interactive_templates/render.py
@@ -1,3 +1,4 @@
+import json
 import shutil
 from importlib.resources import files
 from pathlib import Path
@@ -74,6 +75,9 @@ def _render(schema, template_dir, output_dir, dev_mode=False):
     # write any codelists
     write_codelists(schema, output_dir)
 
+    config = output_dir / "config.json"
+    config.write_text(json.dumps(asdict(schema), indent=2))
+
     context = asdict(schema)
 
     # recursively render/copy files into output_dir
@@ -101,7 +105,7 @@ def write_codelists(schema, output_dir):
         resp.raise_for_status()
 
         path.write_text(resp.text)
-        codelist.path = path.relative_to(output_dir)
+        codelist.path = str(path.relative_to(output_dir))
 
 
 def _render_to(output_dir, context, current_dir, dev_mode=False):

--- a/interactive_templates/templates/v2/analysis/config.py
+++ b/interactive_templates/templates/v2/analysis/config.py
@@ -1,0 +1,5 @@
+import json
+
+
+with open("config.json") as fp:
+    CONFIG = json.load(fp)

--- a/interactive_templates/templates/v2/analysis/study_definition.py
+++ b/interactive_templates/templates/v2/analysis/study_definition.py
@@ -5,6 +5,7 @@ from cohortextractor import (
     params,
     patients,
 )
+from config import CONFIG
 from demographics import get_demographics
 from event_variables import generate_event_variables
 from populations import population_filters
@@ -14,29 +15,25 @@ from report_utils import (
 )
 
 
-codelist_1_path = params["codelist_1_path"]
-codelist_1_type = params["codelist_1_type"]
-codelist_2_path = params["codelist_2_path"]
-codelist_2_type = params["codelist_2_type"]
-time_ever = params["time_ever"].lower() == "true"
-time_value = (
-    None
-    if params["time_value"].lower().strip() in ("none", "")
-    else int(params["time_value"])
-)
-time_scale = (
-    None if params["time_scale"].lower() in ("none", "") else params["time_scale"]
-)
-time_event = params["time_event"]
-codelist_2_comparison_date = params["codelist_2_comparison_date"]
-codelist_1_frequency = params["codelist_1_frequency"]
-population_definition = params["population"]
-breakdowns = params["breakdowns"]
+codelist_1_path = CONFIG["codelist_1"]["path"]
+codelist_1_type = CONFIG["codelist_1"]["type"]
+codelist_2_path = CONFIG["codelist_2"]["path"]
+codelist_2_type = CONFIG["codelist_2"]["type"]
+time_ever = CONFIG["time_ever"]
+time_value = CONFIG["time_value"]
+time_scale = CONFIG["time_scale"]
+time_event = CONFIG["time_event"]
+codelist_2_comparison_date = CONFIG["end_date"]
+population_definition = CONFIG["filter_population"]
+
+# allow --param overrides for weekly run
+codelist_1_frequency = params.get("codelist_1_frequency") or CONFIG["frequency"]
+breakdowns = params.get("breakdowns") or CONFIG["demographics"]
 
 # handle dates
 # TODO: handle events in the same period (week, day, month). Requires form changes
 
-if time_scale is None:
+if time_scale in (None, ""):
     days = 0
 elif time_scale == "weeks":
     days = time_value * 7

--- a/interactive_templates/templates/v2/analysis/study_definition_ethnicity.py
+++ b/interactive_templates/templates/v2/analysis/study_definition_ethnicity.py
@@ -1,4 +1,5 @@
-from cohortextractor import StudyDefinition, codelist_from_csv, params, patients
+from cohortextractor import StudyDefinition, codelist_from_csv, patients
+from config import CONFIG
 
 
 ethnicity_codes = codelist_from_csv(
@@ -9,7 +10,7 @@ ethnicity_codes = codelist_from_csv(
 )
 
 
-end_date = params["end_date"]
+end_date = CONFIG["end_date"]
 
 study = StudyDefinition(
     index_date=end_date,

--- a/interactive_templates/templates/v2/project.yaml.tmpl
+++ b/interactive_templates/templates/v2/project.yaml.tmpl
@@ -8,7 +8,6 @@ actions:
   generate_study_population_ethnicity_{{ id }}:
     run: cohortextractor:latest generate_cohort
       --study-definition study_definition_ethnicity
-      --param end_date="{{ end_date }}"
       --output-dir output/{{ id }} --output-format=feather
     outputs:
       highly_sensitive:
@@ -17,18 +16,7 @@ actions:
   generate_study_population_weekly_{{ id }}:
     run: cohortextractor:latest generate_cohort
       --study-definition study_definition
-      --param codelist_1_path="{{ codelist_1.path }}"
-      --param codelist_1_type="{{ codelist_1.type }}"
-      --param codelist_2_path="{{ codelist_2.path }}"
-      --param codelist_2_type="{{ codelist_2.type }}"
       --param codelist_1_frequency="weekly"
-      --param time_value="{{ time_value }}"
-      --param time_ever="{{ time_ever }}"
-      --param time_scale="{{ time_scale }}"
-      --param time_event="{{ time_event }}"
-      --param codelist_2_comparison_date="end_date"
-      --param operator="AND"
-      --param population="{{ filter_population }}"
       --param breakdowns=""
       --index-date_range="{{ week_of_latest_extract }} to {{ week_of_latest_extract }} by week"
       --output-dir=output/{{ id }}
@@ -41,19 +29,6 @@ actions:
   generate_study_population_{{ id }}:
     run: cohortextractor:latest generate_cohort
       --study-definition study_definition
-      --param codelist_1_path="{{ codelist_1.path }}"
-      --param codelist_1_type="{{ codelist_1.type }}"
-      --param codelist_2_path="{{ codelist_2.path }}"
-      --param codelist_2_type="{{ codelist_2.type }}"
-      --param codelist_1_frequency="{{ frequency }}"
-      --param time_value="{{ time_value }}"
-      --param time_ever="{{ time_ever }}"
-      --param time_scale="{{ time_scale }}"
-      --param time_event="{{ time_event }}"
-      --param codelist_2_comparison_date="end_date"
-      --param operator="AND"
-      --param population="{{ filter_population }}"
-      --param breakdowns="{{ demographics|join(',') }}"
       --index-date-range="{{ start_date }} to {{ end_date }} by month"
       --output-dir=output/{{ id }}
       --output-format=feather

--- a/tests/test_render_cli.py
+++ b/tests/test_render_cli.py
@@ -17,3 +17,5 @@ def test_render_cli(tmp_path):
 
     project = tmp_path / "project.yaml"
     assert "output/1234" in project.read_text()
+    assert (tmp_path / "config.json").exists()
+    assert (tmp_path / "README.md").exists()


### PR DESCRIPTION
Serialising the config into cli args and parsing it was source of bugs.

Instead, we render the *validated* form input as json, and then load
that to access the data in the code.

Everything is validated and typed correctly, no more hand parsing
needed. And simplifies the project.yaml to be more readable.

We do re-use the study definition in the weekly action, so make those
still overloadable via cohortextractor parameters.
