### PR TITLE
Fix practice count

### DIFF
--- a/interactive_templates/templates/v2/analysis/event_counts.py
+++ b/interactive_templates/templates/v2/analysis/event_counts.py
@@ -24,15 +24,17 @@ def replace_zero_with_redacted(x):
     return x if x > 0 else "[REDACTED]"
 
 
-def get_summary_stats(df):
+def get_summary_stats(df, df_practices_dropped):
     required_columns = {"patient_id", "event_measure", "practice"}
     assert required_columns.issubset(set(df.columns))
+    assert required_columns.issubset(set(df_practices_dropped.columns))
 
     unique_patients = df["patient_id"].unique()
     num_events = df["event_measure"].sum()
-    unique_practices = df["practice"].unique()
-    unique_practices_with_events = df.loc[df["event_measure"] == 1, "practice"].unique()
     patients_with_events = df.loc[df["event_measure"] == 1, "patient_id"].unique()
+
+    unique_practices = df["practice"].unique()
+    unique_practices_with_events = df_practices_dropped["practice"].unique()
 
     return {
         "unique_patients": unique_patients,
@@ -78,8 +80,8 @@ def main():
             df["date"] = date
 
             df_practices_dropped = drop_zero_practices(df, "event_measure")
-            # TODO: think about whether we should calculate all of the stats on the dropped data or not
-            summary_stats = get_summary_stats(df_practices_dropped)
+
+            summary_stats = get_summary_stats(df, df_practices_dropped)
             events[date] = summary_stats["num_events"]
             patients.extend(summary_stats["unique_patients"])
             patients_with_events.extend(summary_stats["patients_with_events"])

--- a/interactive_templates/templates/v2/analysis/event_counts.py
+++ b/interactive_templates/templates/v2/analysis/event_counts.py
@@ -31,12 +31,14 @@ def get_summary_stats(df):
     unique_patients = df["patient_id"].unique()
     num_events = df["event_measure"].sum()
     unique_practices = df["practice"].unique()
+    unique_practices_with_events = df.loc[df["event_measure"] == 1, "practice"].unique()
     patients_with_events = df.loc[df["event_measure"] == 1, "patient_id"].unique()
 
     return {
         "unique_patients": unique_patients,
         "num_events": num_events,
         "unique_practices": unique_practices,
+        "unique_practices_with_events": unique_practices_with_events,
         "patients_with_events": patients_with_events,
     }
 
@@ -82,6 +84,7 @@ def main():
             patients.extend(summary_stats["unique_patients"])
             patients_with_events.extend(summary_stats["patients_with_events"])
             practices.extend(summary_stats["unique_practices"])
+            practice_with_events.extend(summary_stats["unique_practices_with_events"])
 
         if match_input_files(file.name, weekly=True):
             date = get_date_input_file(file.name, weekly=True)

--- a/interactive_templates/templates/v2/tests/test_event_counts.py
+++ b/interactive_templates/templates/v2/tests/test_event_counts.py
@@ -24,13 +24,22 @@ def test_round_to_nearest(x, base):
 def test_get_summary_stats():
     data = {
         "patient_id": [1, 1, 2, 3, 4],
-        "event_measure": [1, 0, 1, 1, 0],
+        "event_measure": [1, 0, 1, 0, 0],
         "practice": ["A", "A", "B", "C", "C"],
     }
+
+    data_dropped_practices = {
+        "patient_id": [1, 1, 2],
+        "event_measure": [1, 0, 1],
+        "practice": ["A", "A", "B"],
+    }
     df = pd.DataFrame(data)
-    summary_stats = event_counts.get_summary_stats(df)
+    df_practices_dropped = pd.DataFrame(data_dropped_practices)
+
+    summary_stats = event_counts.get_summary_stats(df, df_practices_dropped)
 
     assert (summary_stats["unique_patients"] == [1, 2, 3, 4]).all()
-    assert summary_stats["num_events"] == 3
+    assert summary_stats["num_events"] == 2
     assert (summary_stats["unique_practices"] == ["A", "B", "C"]).all()
-    assert (summary_stats["patients_with_events"] == [1, 2, 3]).all()
+    assert (summary_stats["unique_practices_with_events"] == ["A", "B"]).all()
+    assert (summary_stats["patients_with_events"] == [1, 2]).all()


### PR DESCRIPTION
Fixes #160 .

Whilst here, it also deals with the outstanding TODO for events counts. We had been calculating all summary counts using a subset of the data where only practices with events were included. As we're including the total population in the summary counts, this should include patients within "zero practices". 