### PR TITLE
Handle arbitrary subdomain sequences correctly

### DIFF
--- a/interactive_templates/create.py
+++ b/interactive_templates/create.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from urllib.parse import urlparse, urlunparse
 
 from interactive_templates.render import render_analysis
 
@@ -61,8 +62,11 @@ def commit_and_push(working_dir, analysis, force=False):
 
 
 def get_repo_with_token(repo, token):
-    if repo.startswith("https://github.com"):
-        return repo.replace("https://", f"https://interactive:{token}@")
+    scheme, netloc, path, params, query, fragment = urlparse(repo)
+    if scheme == "https" and netloc == "github.com":
+        new_netloc = f"interactive:{token}@{netloc}"
+        return urlunparse((scheme, new_netloc, path, params, query, fragment))
+
     return repo
 
 

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -177,6 +177,12 @@ def test_get_repo_with_token_returns_correct_url_with_token():
     assert create.get_repo_with_token(repo, "a_secure_token") == expected_repo
 
 
-@pytest.mark.parametrize("repo", ["/tmp/opensafely-test/my-test-repo"])
+@pytest.mark.parametrize(
+    "repo",
+    [
+        "/tmp/opensafely-test/my-test-repo",
+        "https://github.com.someothersite.net/opensafely-test/my-test-repo",
+    ],
+)
 def test_get_repo_with_token_returns_same_url_with_no_token(repo):
     assert create.get_repo_with_token(repo, "a_secure_token") == repo

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -177,7 +177,6 @@ def test_get_repo_with_token_returns_correct_url_with_token():
     assert create.get_repo_with_token(repo, "a_secure_token") == expected_repo
 
 
-def test_get_repo_with_token_returns_same_url_with_no_token():
-    repo = "/tmp/opensafely-test/my-test-repo"
-
+@pytest.mark.parametrize("repo", ["/tmp/opensafely-test/my-test-repo"])
+def test_get_repo_with_token_returns_same_url_with_no_token(repo):
     assert create.get_repo_with_token(repo, "a_secure_token") == repo

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -168,7 +168,7 @@ def test_create_commit(remote_repo, add_codelist, force):
     assert commit_in_remote(remote=remote_repo, commit=sha)
 
 
-def test_get_repo_with_token_returns_correct_url_with_token(monkeypatch):
+def test_get_repo_with_token_returns_correct_url_with_token():
     repo = "https://github.com/opensafely-test/my-test-repo"
     expected_repo = (
         "https://interactive:a_secure_token@github.com/opensafely-test/my-test-repo"


### PR DESCRIPTION
Treating the URL (`repo`) as a string and checking if an allowed host is a substring of the URL is prone to errors. Instead, we parse the URL before performing a check on its host value.

Fixes #361