### PR TITLE
Fetch all commits when tagging new release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Tag new release
         run: |
           # ignore failures here to avoid merges into main without version


### PR DESCRIPTION
See #363.

As things stand, GitHub Actions can clone the repository without all existing tags. If the `version` hasn't been updated, then this `tag-new-release` workflow job will always tag the commit being checked out with the tag in `version`. As this tag should already exist from a previous run of this workflow, the `git push --tags` step fails.