### PR TITLE
Fix quirks in pandas test behaviour

### DIFF
--- a/interactive_templates/templates/v2/tests/test_measures.py
+++ b/interactive_templates/templates/v2/tests/test_measures.py
@@ -100,8 +100,8 @@ def test_calculate_total_counts(df):
 
     obs = measures.calculate_total_counts(df, date, group="total", group_value="total")
 
-    assert obs["group"].all() == "total"
-    assert obs["group_value"].all() == "total"
+    assert obs["group"].eq("total").all()
+    assert obs["group_value"].eq("total").all()
 
     assert len(obs) == 1
     assert obs.columns.tolist() == [
@@ -113,7 +113,7 @@ def test_calculate_total_counts(df):
     ]
 
     # assert date is correct
-    assert obs["date"].all() == date
+    assert obs["date"].eq(date).all()
 
     # assert that the sum of the event_measure and population columns is correct
     assert obs["event_measure"].iloc[0] == df["event_measure"].sum()
@@ -139,7 +139,7 @@ def test_calculate_group_counts(df):
     ]
 
     # assert date is correct
-    assert obs["date"].all() == date
+    assert obs["date"].eq(date).all()
 
     # assert that the sum of the event_measure and population columns is correct
     assert (


### PR DESCRIPTION
For the current state of the code, this change is not required. It will, however, save someone fixing this in future, when actually wanting to use a newer OpenSAFELY Python image.

However, the tests currently rely on a quirky behaviour of `.all()` in pandas that has been fixed.

In the version of pandas inside the `python:latest` image (v1.0.1), the behaviour is that `.all()` can return an `dtype=object` instead of a Boolean, and our tests as written pass.

In later versions of pandas, `.all()` returns a Boolean instead, and our tests fail.

We can rewrite the tests to work both prior to and post this pandas fix.

This was checked by running the tests with the `Dockerfile` as provided, and editing the `Dockerfile` to use the `v2` OpenSAFELY Python image.

See pandas-dev/pandas#12863.