### PR TITLE
Update Python to 3.12 for job-server PR workflow

### DIFF
--- a/.github/workflows/create-job-server-pr.yml
+++ b/.github/workflows/create-job-server-pr.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: opensafely-core/setup-action@v1
         with:
           install-just: true
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Update requirement to latest
         run: just update-interactive-templates "$GITHUB_SHA"


### PR DESCRIPTION
job-server uses Python 3.12, so we need it here in this workflow, otherwise job-server's `just` recipe fails.

Thanks to @lucyb for realising what happened when we were chatting, saving me from investigating it.