### PR TITLE
Specify tag in job-server PR workflow

### DIFF
--- a/.github/workflows/create-job-server-pr.yml
+++ b/.github/workflows/create-job-server-pr.yml
@@ -27,8 +27,11 @@ jobs:
           python-version: "3.12"
 
       - name: Update requirement to latest
+        id: update-requirement
         run: |
-          just update-interactive-templates "$(git describe --tags)"
+          just update-interactive-templates
+          updated_version="$(sed -n 's|^interactive_templates@https://github.com/opensafely-core/interactive-templates/archive/refs/tags/\(v[0-9.].*\).zip$|\1|p' requirements.prod.in)"
+          echo "UPDATED_VERSION=$updated_version" >> "$GITHUB_ENV"
 
       - name: Create a Pull Request if there are any changes
         id: create_pr
@@ -36,9 +39,9 @@ jobs:
         with:
           token: "${{ secrets.JOB_SERVER_PR_TOKEN }}"
           branch: bot/update-interactive-templates
-          commit-message: "feat: Update interactive templates to latest version"
-          title: "Update interactive templates to latest version"
-          body: "Update interative-templates to ${{ github.sha }}"
+          commit-message: "feat: Update interactive templates to ${{ env.UPDATED_VERSION }}"
+          title: "Update interactive templates to ${{ env.UPDATED_VERSION }}"
+          body: "Update interactive-templates to ${{ env.UPDATED_VERSION }}"
 
       # untested
       #- name: Enable automerge

--- a/.github/workflows/create-job-server-pr.yml
+++ b/.github/workflows/create-job-server-pr.yml
@@ -27,7 +27,8 @@ jobs:
           python-version: "3.12"
 
       - name: Update requirement to latest
-        run: just update-interactive-templates "$GITHUB_SHA"
+        run: |
+          just update-interactive-templates "$(git describe --tags)"
 
       - name: Create a Pull Request if there are any changes
         id: create_pr


### PR DESCRIPTION
See also #118.

This largely fixes the "create a PR in the job-server repository" workflow.

The existing token is currently expired, so the workflow now fails due to that, which is just about the last step of creating a PR.

*However*, it may be better to do as ehrQL does and actually move this workflow to the repository where the PR is getting created, then check for updates for interactive-templates. The only drawbacks:

* PRs are created on a daily schedule, or when a manual run is triggered.
* you have to do the close and then open PR task before CI runs

I'm not sure that's such a problem when the number of updates is so infrequent here. It does remove all the hassle of dealing with tokens (as in ebmdatalab/metrics#194).

I'll include these fixes here for reference in any case.