### PR TITLE
Handle `git tag` failure more gracefully

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           # ignore failures here to avoid merges into main without version
           # bumps failing this job.
-          git tag "v$(cat version)" || exit
+          git tag "v$(cat version)" || exit 0
           git push --tags
 
   required-checks:


### PR DESCRIPTION
`man bash` on `exit`:

> If n is omitted, the exit status is that of the last command executed.

If the `git tag` fails, then the exit status is then also an error code and GitHub Actions helpfully sends whoever triggered the workflow a notification.