### PR TITLE
Have Dependabot ignore Hypothesis

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 20
 
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 20
+    ignore:
+      - dependency-name: hypothesis
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Because of the hybrid nature of this repo (Python 3.8/3.11), we're unable to keep updating Hypothesis. Given that OSI is "sunsetted", it seems reasonable to have Dependabot ignore it.

Fixes #423